### PR TITLE
fix(RPS-1309): read(robot, "pose") now considers the default_tcp

### DIFF
--- a/wandelscript/metamodel.py
+++ b/wandelscript/metamodel.py
@@ -480,9 +480,7 @@ class Motion(Statement):
                 )
             tcp = tcp.name  # TODO messy
         else:
-            tcp = context.store.get(
-                "__tcp__", None
-            )  # TODO how can the __tcp__ naming be connected to the corresponding builtin function (tcp)
+            tcp = context.default_tcp
             if tcp is None:
                 msg = "No tool is defined. Please define one using the 'tcp' function!"
                 raise wandelscript.exception.UserError(location=self.location, value=msg)
@@ -1560,7 +1558,7 @@ class Read(Atom[ElementType]):
         try:
             if isinstance(device, AbstractRobot):
                 if key == "pose":
-                    action = ReadPoseAction(device_id=device.id, tcp=None)
+                    action = ReadPoseAction(device_id=device.id, tcp=context.default_tcp)
                 elif key == "joints":
                     action = ReadJointsAction(device_id=device.id)
                 else:

--- a/wandelscript/runtime.py
+++ b/wandelscript/runtime.py
@@ -180,6 +180,11 @@ class ExecutionContext:
         return self._default_robot
 
     @property
+    def default_tcp(self) -> str | None:
+        # TODO how can the __tcp__ naming be connected to the corresponding builtin function (tcp)
+        return self.store.get("__tcp__", None)
+
+    @property
     def active_robot(self) -> str:
         """Return the robot that should be used for execution.
 
@@ -247,8 +252,8 @@ class ExecutionContext:
 
     async def read_pose(self, robot_name: str, tcp: str | None = None) -> Pose:
         tcp = tcp or await self.get_robot(robot_name).active_tcp_name()
-        tcp_pose = await self.get_robot(robot_name).get_state(tcp)
-        return tcp_pose.pose
+        robot_state = await self.get_robot(robot_name).get_state(tcp)
+        return robot_state.pose
 
     async def read_joints(self, robot_name: str) -> tuple:
         tcp = await self.get_robot(robot_name).active_tcp_name()


### PR DESCRIPTION
read(robot, "pose") now considers the default_tcp - if it is set - before using the robots active TCP.

Reading the current pose of a robot using read(robot, "pose") always returned the pose using the active TCP of the robot. It now first tries to get and use the default TCP and if this is not set falls back to the active TCP.