### PR TITLE
chore(RPS-1310): Replace shortcut actions with verbose names

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2122,14 +2122,14 @@ websockets = "*"
 
 [[package]]
 name = "wandelbots-nova"
-version = "0.47.0"
+version = "0.47.3"
 description = "Official Python SDK for the Wandelbots"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "wandelbots_nova-0.47.0-py3-none-any.whl", hash = "sha256:30b12c054a079235523c27426ca1059bfea120a96468083578be883b6acf1487"},
-    {file = "wandelbots_nova-0.47.0.tar.gz", hash = "sha256:6fc7215e1484e90b782f90a8893a05aca453760539e2e6fa7797eb2c6c3a764e"},
+    {file = "wandelbots_nova-0.47.3-py3-none-any.whl", hash = "sha256:0614cca98bd1c3b866522b4596d8cde144baf276622c7566e3e3314b09ddd7f7"},
+    {file = "wandelbots_nova-0.47.3.tar.gz", hash = "sha256:d801fbcdb4210573f86b98c4d834c0016d9d1ace9ca0e0efd35e20a8cf6836db"},
 ]
 
 [package.dependencies]
@@ -2357,4 +2357,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "0b655479c09bc8d4febe48894a29e377930596ed78805ae5a4f0a2a1556d438a"
+content-hash = "71b610289dd935860c2eedc0c23d2d662bfd61e258f6385706b0ebb088e910c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ antlr4-python3-runtime = "4.13.1"
 anyio = "^4"
 numpy = "^2.2.1"
 pydantic = "^2.10.3"
-wandelbots-nova = "^0.47.0"
+wandelbots-nova = "^0.47.3"
 exceptiongroup = "^1.2.2"
 geometricalgebra = "^0.1.3"
 # TODO: would like to remove this dependency

--- a/wandelscript/motions.py
+++ b/wandelscript/motions.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from nova.actions import cir, jnt, lin, ptp
-from nova.actions.motions import PTP, Circular, JointPTP, Linear
+from nova.actions.motions import CartesianPTP, Circular, JointPTP, Linear
 from nova.types import MotionSettings, Pose, Vector3d
 
 from wandelscript.exception import GenericRuntimeError
@@ -35,14 +35,14 @@ class Line(Connector.Impl, func_name="line"):
 class PointToPoint(Line, func_name="ptp"):
     def __call__(
         self, start: Pose | None, end: Pose, args: Connector.Impl.Args, motion_settings: MotionSettings
-    ) -> PTP:
+    ) -> CartesianPTP:
         return ptp(end.to_tuple(), settings=motion_settings)
 
 
 class Point2Point(PointToPoint, func_name="p2p"):
     def __call__(
         self, start: Pose | None, end: Pose, args: Connector.Impl.Args, motion_settings: MotionSettings
-    ) -> PTP:
+    ) -> CartesianPTP:
         return ptp(end.to_tuple(), settings=motion_settings)
 
 

--- a/wandelscript/motions.py
+++ b/wandelscript/motions.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from nova.actions import cir, jnt, lin, ptp
+from nova.actions import cartesian_ptp, circular, joint_ptp, linear
 from nova.actions.motions import CartesianPTP, Circular, JointPTP, Linear
 from nova.types import MotionSettings, Pose, Vector3d
 
@@ -13,7 +13,7 @@ class JointPointToPoint(Connector.Impl, func_name="joint_ptp"):
     def __call__(
         self, start: Pose | None, end: tuple[float, ...], args: Connector.Impl.Args, motion_settings: MotionSettings
     ) -> JointPTP:
-        return jnt(end, settings=motion_settings)
+        return joint_ptp(end, settings=motion_settings)
 
 
 @dataclass(repr=False)
@@ -21,7 +21,7 @@ class JointPoint2Point(JointPointToPoint, func_name="joint_p2p"):
     def __call__(
         self, start: Pose | None, end: tuple[float, ...], args: Connector.Impl.Args, motion_settings: MotionSettings
     ) -> JointPTP:
-        return jnt(end, settings=motion_settings)
+        return joint_ptp(end, settings=motion_settings)
 
 
 @dataclass(repr=False)
@@ -29,21 +29,21 @@ class Line(Connector.Impl, func_name="line"):
     def __call__(
         self, start: Pose | None, end: Pose, args: Connector.Impl.Args, motion_settings: MotionSettings
     ) -> Linear:
-        return lin(end.to_tuple(), settings=motion_settings)
+        return linear(end.to_tuple(), settings=motion_settings)
 
 
 class PointToPoint(Line, func_name="ptp"):
     def __call__(
         self, start: Pose | None, end: Pose, args: Connector.Impl.Args, motion_settings: MotionSettings
     ) -> CartesianPTP:
-        return ptp(end.to_tuple(), settings=motion_settings)
+        return cartesian_ptp(end.to_tuple(), settings=motion_settings)
 
 
 class Point2Point(PointToPoint, func_name="p2p"):
     def __call__(
         self, start: Pose | None, end: Pose, args: Connector.Impl.Args, motion_settings: MotionSettings
     ) -> CartesianPTP:
-        return ptp(end.to_tuple(), settings=motion_settings)
+        return cartesian_ptp(end.to_tuple(), settings=motion_settings)
 
 
 @dataclass(repr=False)
@@ -57,4 +57,4 @@ class Arc(Connector.Impl, func_name="arc"):
             intermediate = args.intermediate
         else:
             raise GenericRuntimeError(location=None, text="Intermediate must be a pose")
-        return cir(end.to_tuple(), intermediate.to_tuple(), settings=motion_settings)
+        return circular(end.to_tuple(), intermediate.to_tuple(), settings=motion_settings)

--- a/wandelscript/simulation.py
+++ b/wandelscript/simulation.py
@@ -8,7 +8,7 @@ from typing import Any, AsyncIterable, Literal, SupportsIndex
 import numpy as np
 from nova import api
 from nova.actions import Action, MovementController
-from nova.actions.motions import PTP, Circular, JointPTP, Linear
+from nova.actions.motions import CartesianPTP, Circular, JointPTP, Linear
 from nova.core.io import ValueType
 from nova.core.robot_cell import (
     AbstractController,
@@ -218,11 +218,11 @@ class SimulatedRobot(ConfigurablePeriphery, AbstractRobot):
                 # Directly use the target as the final joints
                 final_joints = np.array(action.target, dtype=float)
 
-            elif isinstance(action, (Linear, PTP, Circular)):
+            elif isinstance(action, (Linear, CartesianPTP, Circular)):
                 # Very naive approach: do a "fake IK" from the pose
                 if not isinstance(action.target, Pose):
                     # If user gave a vector or something else, you'd need to convert
-                    # but from your code, PTP/Linear typically store Pose internally
+                    # but from your code, CartesianPTP/Linear typically store Pose internally
                     raise ValueError(f"Expected Pose as target, got {type(action.target)}")
 
                 final_joints = naive_cartesian_to_joints(action.target)

--- a/wandelscript/tests/test_motion.py
+++ b/wandelscript/tests/test_motion.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from nova.actions.motions import PTP, JointPTP, Linear
+from nova.actions.motions import CartesianPTP, JointPTP, Linear
 from nova.core.robot_cell import RobotCell
 from nova.types import Pose
 
@@ -53,7 +53,7 @@ sync
 move via line() to (21, 0, 1111, 0, 0, 0)
 move via ptp() to (23, 0, 626, 0, 0, 0)
 """
-    expected_motion_types = [[PTP, Linear, PTP], [PTP, Linear], [Linear, PTP]]
+    expected_motion_types = [[CartesianPTP, Linear, CartesianPTP], [CartesianPTP, Linear], [Linear, CartesianPTP]]
 
     cell = get_robot_cell()
     runner = wandelscript.run(code, cell, default_tcp="Flange")
@@ -90,40 +90,40 @@ move via joint_p2p() to [31, 0, 626, 0, 0, 0]
     expected_joint_values = [
         [(1, 0, 626, 0, 0, 0), None, None, (4, 0, 626, 0, 0, 0), (5, 0, 626, 0, 0, 0), (6, 0, 626, 0, 0, 0)],
         [
-            # After a sync there will always first be a PTP motion added (this point has joints of a previous point)
+            # After a sync there will always first be a CartesianPTP motion added (this point has joints of a previous point)
             (6, 0, 626, 0, 0, 0),
             (11, 0, 626, 0, 0, 0),
             None,
         ],
         [
-            # After a sync there will always first be a PTP motion added
+            # After a sync there will always first be a CartesianPTP motion added
             None,
             None,
             (23, 0, 626, 0, 0, 0),
         ],
         [
-            # After a sync there will always first be a PTP motion added
+            # After a sync there will always first be a CartesianPTP motion added
             (23, 0, 626, 0, 0, 0),
             (31, 0, 626, 0, 0, 0),
         ],
     ]
 
     expected_motion_types = [
-        [JointPTP, Linear, PTP, JointPTP, JointPTP, JointPTP],
+        [JointPTP, Linear, CartesianPTP, JointPTP, JointPTP, JointPTP],
         [
-            # After a sync there will always first be a PTP motion added
+            # After a sync there will always first be a CartesianPTP motion added
             JointPTP,
             JointPTP,
             Linear,
         ],
         [
-            # After a sync there will always first be a PTP motion added
+            # After a sync there will always first be a CartesianPTP motion added
             Linear,
             Linear,
             JointPTP,
         ],
         [
-            # After a sync there will always first be a PTP motion added
+            # After a sync there will always first be a CartesianPTP motion added
             JointPTP,
             JointPTP,
         ],

--- a/wandelscript/tests/test_move.py
+++ b/wandelscript/tests/test_move.py
@@ -2,7 +2,7 @@ import asyncio
 
 import numpy as np
 import pytest
-from nova.actions import CombinedActions, lin, ptp
+from nova.actions import CombinedActions, cartesian_ptp, linear
 from nova.types import MotionSettings, Pose
 
 from wandelscript.metamodel import run_program
@@ -24,11 +24,11 @@ move tcp via ptp() to (150, -355, 389, 0, pi, 0)
             [
                 CombinedActions(
                     items=(
-                        ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
-                        lin((150, -355, 392), MotionSettings(tcp_velocity_limit=10)),
-                        ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
-                        lin((-95, -363, 387), MotionSettings(tcp_velocity_limit=250)),
-                        ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
+                        cartesian_ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
+                        linear((150, -355, 392), MotionSettings(tcp_velocity_limit=10)),
+                        cartesian_ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
+                        linear((-95, -363, 387), MotionSettings(tcp_velocity_limit=250)),
+                        cartesian_ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
                     )
                 )
             ],
@@ -45,11 +45,11 @@ move via ptp() to (150, -355, 389, 0, pi, 0)
             [
                 CombinedActions(
                     items=(
-                        ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
-                        lin((150, -355, 392), MotionSettings(tcp_velocity_limit=10)),
-                        ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
-                        lin((-95, -363, 387), MotionSettings(tcp_velocity_limit=250)),
-                        ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
+                        cartesian_ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
+                        linear((150, -355, 392), MotionSettings(tcp_velocity_limit=10)),
+                        cartesian_ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
+                        linear((-95, -363, 387), MotionSettings(tcp_velocity_limit=250)),
+                        cartesian_ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=200)),
                     )
                 )
             ],
@@ -65,11 +65,11 @@ move via ptp() to (150, -355, 389, 0, pi, 0)
             [
                 CombinedActions(
                     items=(
-                        ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=None)),
-                        lin((150, -355, 392), MotionSettings(position_zone_radius=2)),
-                        ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=100)),
-                        lin((-95, -363, 387), MotionSettings(position_zone_radius=4)),
-                        ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=None)),
+                        cartesian_ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=None)),
+                        linear((150, -355, 392), MotionSettings(position_zone_radius=2)),
+                        cartesian_ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=100)),
+                        linear((-95, -363, 387), MotionSettings(position_zone_radius=4)),
+                        cartesian_ptp((150, -355, 389), MotionSettings(tcp_velocity_limit=None)),
                     )
                 )
             ],

--- a/wandelscript/tests/test_runtime.py
+++ b/wandelscript/tests/test_runtime.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import pytest
-from nova.actions import cir, io_write, lin, ptp
+from nova.actions import cartesian_ptp, circular, io_write, linear
 from nova.actions.container import ActionLocation
 from nova.core.robot_cell import RobotCell
 from nova.types import Pose
@@ -150,7 +150,7 @@ async def test_run():
     cell = RobotCell(controller=controller)
     execution_context = ExecutionContext(cell, asyncio.Event())
     queue = ActionQueue(execution_context)
-    motions = [lin((400, 0, 0, 0, 0, 0)), cir((500, 0, 0), (0, 0, 0)), ptp((500, 0, 0))]
+    motions = [linear((400, 0, 0, 0, 0, 0)), circular((500, 0, 0), (0, 0, 0)), cartesian_ptp((500, 0, 0))]
     for motion in motions:
         queue.push(motion, tool="Flange", motion_group_id=robot.id)
 

--- a/wandelscript/tests/test_simulation.py
+++ b/wandelscript/tests/test_simulation.py
@@ -1,5 +1,5 @@
 import pytest
-from nova.actions.motions import PTP, JointPTP
+from nova.actions.motions import CartesianPTP, JointPTP
 from nova.types import MotionState, RobotState
 
 from wandelscript.simulation import SimulatedRobot, naive_joints_to_pose
@@ -22,11 +22,11 @@ async def test_simulated_robot_execution():
 
     # 2. Define some actions for the robot to plan:
     #    a) Move joints directly to [0, 1, 2, 0, 0, 0] with JointPTP
-    #    b) Then move to a cartesian Pose using naive IK with PTP
+    #    b) Then move to a cartesian Pose using naive IK with CartesianPTP
     joint_target = (0, 1, 2, 0, 0, 0)
     cartesian_target = Pose((100, 200, 300, 10, 20, 30))  # x=100mm, y=200mm, z=300mm, rx=10°, ry=20°, rz=30°
 
-    actions = [JointPTP(target=joint_target), PTP(target=cartesian_target)]
+    actions = [JointPTP(target=joint_target), CartesianPTP(target=cartesian_target)]
 
     # 3. Plan the trajectory
     trajectory = await robot._plan(actions, tcp="Flange")
@@ -54,7 +54,7 @@ async def test_simulated_robot_execution():
     final_state = await robot.get_state("Flange")
     final_joints = final_state.joints
 
-    # The last action was PTP to cartesian_target. Because of naive "IK",
+    # The last action was CartesianPTP to cartesian_target. Because of naive "IK",
     # let's see if the final_joints produce a Pose close to cartesian_target.
     # We'll just do a simple check that naive_joints_to_pose is near the cartesian target.
     final_pose = naive_joints_to_pose(final_joints)


### PR DESCRIPTION
Also consequently replace Replace `PTP` with `CartesianPTP`.

Also require the newer version of nova that brings this change about.

Notably: THIS DOES NOT TOUCH UPON THE KEYWORDS IN THE WANDELSCRIPT LANGUAGE /shout