### PR TITLE
fix(RPS-1490): Make 2 motion classes dataclasses

### DIFF
--- a/wandelscript/motions.py
+++ b/wandelscript/motions.py
@@ -32,13 +32,15 @@ class Line(Connector.Impl, func_name="line"):
         return linear(end.to_tuple(), settings=motion_settings)
 
 
-class PointToPoint(Line, func_name="ptp"):
+@dataclass(repr=False)
+class PointToPoint(Connector.Impl, func_name="ptp"):
     def __call__(
         self, start: Pose | None, end: Pose, args: Connector.Impl.Args, motion_settings: MotionSettings
     ) -> CartesianPTP:
         return cartesian_ptp(end.to_tuple(), settings=motion_settings)
 
 
+@dataclass(repr=False)
 class Point2Point(PointToPoint, func_name="p2p"):
     def __call__(
         self, start: Pose | None, end: Pose, args: Connector.Impl.Args, motion_settings: MotionSettings


### PR DESCRIPTION
Just like their siblings.

Also inherit one of them from `Connector.Impl` instead of from `Line`. Don't know why it inherited from Line tbh.