### PR TITLE
chore: Relax `typer` version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "exceptiongroup>=1.2.2,<2",
     "geometricalgebra>=0.1.3,<0.2",
     "python-dotenv>=1.0.1,<2",
-    "typer[all]>=0.15.2,<0.16",
+    "typer[all]>=0.12,<0.16",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1579,7 +1579,7 @@ wheels = [
 
 [[package]]
 name = "wandelscript"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiostream" },
@@ -1621,7 +1621,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.2.1,<3" },
     { name = "pydantic", specifier = ">=2.10.3,<3" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
-    { name = "typer", extras = ["all"], specifier = ">=0.15.2,<0.16" },
+    { name = "typer", extras = ["all"], specifier = ">=0.12,<0.16" },
     { name = "wandelbots-nova", specifier = ">=0.48.1" },
 ]
 


### PR DESCRIPTION
We want to use https://github.com/koxudaxi/fastapi-code-generator

to generate Python stubs from service-manager OpenAPI YAML endpoint definitions. Problem is that this tool requires `typer<0.13` to be installed.

Thus relax the constraints on `typer`.